### PR TITLE
fix: 添加音视频元素的空值检查，防止空引用错误

### DIFF
--- a/web/client.js
+++ b/web/client.js
@@ -56,16 +56,17 @@ function start() {
     // connect audio / video
     pc.addEventListener('track', (evt) => {
         if (evt.track.kind == 'video') {
-            document.getElementById('video').srcObject = evt.streams[0];
+            const videoEl = document.getElementById('video');
+            if (videoEl) {
+                videoEl.srcObject = evt.streams[0];
+            }
         } else {
-            document.getElementById('audio').srcObject = evt.streams[0];
+            const audioEl = document.getElementById('audio');
+            if (audioEl) {
+                audioEl.srcObject = evt.streams[0];
+            }
         }
     });
-
-    document.getElementById('start').style.display = 'none';
-    negotiate();
-    document.getElementById('stop').style.display = 'inline-block';
-}
 
 function stop() {
     document.getElementById('stop').style.display = 'none';


### PR DESCRIPTION
- 在设置 srcObject 前检查元素是否存在
- 避免元素不存在时的空引用错误