### PR TITLE
feat: integrate local SenseVoice ASR server to resolve #604

### DIFF
--- a/benchmark_asr.py
+++ b/benchmark_asr.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+###############################################################################
+#  ASR Latency Benchmark — SenseVoice Small vs OpenAI Whisper Tiny
+#
+#  Usage:
+#      python benchmark_asr.py                    # uses TTS-generated speech
+#      python benchmark_asr.py --audio test.wav   # uses your own audio file
+#      python benchmark_asr.py --runs 10          # more runs for stability
+#
+#  Resolves: https://github.com/lipku/LiveTalking/issues/604
+###############################################################################
+
+import argparse
+import asyncio
+import io
+import os
+import sys
+import time
+import tempfile
+
+import numpy as np
+import soundfile as sf
+
+
+# ─── Utilities ─────────────────────────────────────────────────────────────
+
+def generate_test_audio_tts(text: str, output_path: str) -> bool:
+    """Generate real speech audio using edge_tts (requires network)."""
+    try:
+        import edge_tts
+
+        async def _gen():
+            communicate = edge_tts.Communicate(text, "en-US-AriaNeural")
+            await communicate.save(output_path)
+
+        asyncio.run(_gen())
+        print(f"  ✅ Generated speech audio via edge_tts → {output_path}")
+        return True
+    except Exception as e:
+        print(f"  ⚠️  edge_tts failed ({e}), falling back to synthetic audio")
+        return False
+
+
+def generate_synthetic_audio(duration_s: float, sample_rate: int = 16000) -> np.ndarray:
+    """Generate a synthetic audio signal (speech-like noise burst)."""
+    rng = np.random.default_rng(42)
+    # Mix of tones + noise to loosely simulate speech energy distribution
+    t = np.linspace(0, duration_s, int(sample_rate * duration_s), dtype=np.float32)
+    audio = (
+        0.3 * np.sin(2 * np.pi * 200 * t) +
+        0.2 * np.sin(2 * np.pi * 500 * t) +
+        0.1 * np.sin(2 * np.pi * 1200 * t) +
+        0.15 * rng.standard_normal(len(t)).astype(np.float32)
+    )
+    # Fade in/out
+    fade = int(0.05 * sample_rate)
+    audio[:fade] *= np.linspace(0, 1, fade)
+    audio[-fade:] *= np.linspace(1, 0, fade)
+    return audio.astype(np.float32)
+
+
+def load_audio(path: str, target_sr: int = 16000) -> np.ndarray:
+    """Load and resample audio to target sample rate."""
+    import librosa
+    audio, sr = librosa.load(path, sr=target_sr, mono=True)
+    return audio.astype(np.float32)
+
+
+def format_table(headers, rows, col_widths=None):
+    """Simple markdown table formatter."""
+    if col_widths is None:
+        col_widths = [max(len(str(h)), max(len(str(r[i])) for r in rows))
+                      for i, h in enumerate(headers)]
+
+    def fmt_row(cells):
+        return "| " + " | ".join(str(c).ljust(w) for c, w in zip(cells, col_widths)) + " |"
+
+    sep = "|" + "|".join("-" * (w + 2) for w in col_widths) + "|"
+    lines = [fmt_row(headers), sep] + [fmt_row(r) for r in rows]
+    return "\n".join(lines)
+
+
+# ─── Whisper Tiny Benchmark ───────────────────────────────────────────────
+
+def benchmark_whisper_tiny(audio: np.ndarray, sample_rate: int, num_runs: int):
+    """Benchmark OpenAI Whisper Tiny for speech-to-text."""
+    import torch
+    from transformers import WhisperProcessor, WhisperForConditionalGeneration
+
+    print("\n🔧 Loading Whisper Tiny (openai/whisper-tiny)...")
+    t0 = time.perf_counter()
+    processor = WhisperProcessor.from_pretrained("openai/whisper-tiny")
+    model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny")
+    model.eval()
+    load_time = time.perf_counter() - t0
+    print(f"   Loaded in {load_time:.1f}s")
+
+    # Warm-up run (not timed)
+    print("   Warm-up run...")
+    input_features = processor(
+        audio, sampling_rate=sample_rate, return_tensors="pt"
+    ).input_features
+    with torch.no_grad():
+        model.generate(input_features, max_new_tokens=128)
+
+    # Timed runs
+    times = []
+    last_text = ""
+    for i in range(num_runs):
+        t = time.perf_counter()
+        input_features = processor(
+            audio, sampling_rate=sample_rate, return_tensors="pt"
+        ).input_features
+        with torch.no_grad():
+            predicted_ids = model.generate(input_features, max_new_tokens=128)
+        last_text = processor.batch_decode(predicted_ids, skip_special_tokens=True)[0]
+        elapsed = (time.perf_counter() - t) * 1000
+        times.append(elapsed)
+        print(f"   Run {i+1}/{num_runs}: {elapsed:.0f}ms")
+
+    return times, last_text
+
+
+# ─── SenseVoice Benchmark ─────────────────────────────────────────────────
+
+def benchmark_sensevoice(audio: np.ndarray, sample_rate: int, num_runs: int):
+    """Benchmark SenseVoice Small for speech-to-text."""
+    import torch
+    from funasr import AutoModel
+    from funasr.utils.postprocess_utils import rich_transcription_postprocess
+
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    print(f"\n🔧 Loading SenseVoice Small (iic/SenseVoiceSmall) on {device}...")
+    t0 = time.perf_counter()
+    model = AutoModel(
+        model="iic/SenseVoiceSmall",
+        vad_model="fsmn-vad",
+        vad_kwargs={"max_single_segment_time": 30000},
+        device=device,
+        trust_remote_code=True,
+    )
+    load_time = time.perf_counter() - t0
+    print(f"   Loaded in {load_time:.1f}s")
+
+    # Prepare WAV in memory
+    wav_buf = io.BytesIO()
+    sf.write(wav_buf, audio, sample_rate, format="WAV")
+
+    # Warm-up run
+    print("   Warm-up run...")
+    wav_buf.seek(0)
+    model.generate(input=wav_buf, cache={}, language="auto", use_itn=True, batch_size_s=60)
+
+    # Timed runs
+    times = []
+    last_text = ""
+    for i in range(num_runs):
+        wav_buf.seek(0)
+        t = time.perf_counter()
+        res = model.generate(
+            input=wav_buf, cache={}, language="auto", use_itn=True, batch_size_s=60
+        )
+        elapsed = (time.perf_counter() - t) * 1000
+        last_text = rich_transcription_postprocess(res[0]["text"]) if res and res[0].get("text") else ""
+        times.append(elapsed)
+        print(f"   Run {i+1}/{num_runs}: {elapsed:.0f}ms")
+
+    return times, last_text
+
+
+# ─── Main ──────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ASR Latency Benchmark: SenseVoice Small vs Whisper Tiny"
+    )
+    parser.add_argument("--audio", type=str, default=None,
+                        help="Path to a WAV/MP3 audio file (default: auto-generate)")
+    parser.add_argument("--runs", type=int, default=5,
+                        help="Number of timed inference runs per model (default: 5)")
+    parser.add_argument("--duration", type=float, default=5.0,
+                        help="Duration of generated test audio in seconds (default: 5)")
+    args = parser.parse_args()
+
+    sample_rate = 16000
+    print("=" * 60)
+    print("  ASR Latency Benchmark")
+    print("  SenseVoice Small  vs  OpenAI Whisper Tiny")
+    print("=" * 60)
+
+    import torch
+    device = "CUDA" if torch.cuda.is_available() else "CPU"
+    print(f"\n📊 Device: {device}")
+    print(f"📊 Runs per model: {args.runs}")
+
+    # ── Prepare test audio ──────────────────────────────────────────────
+    if args.audio and os.path.exists(args.audio):
+        print(f"\n🎵 Loading audio from: {args.audio}")
+        audio = load_audio(args.audio, target_sr=sample_rate)
+    else:
+        print(f"\n🎵 Generating {args.duration}s test audio...")
+        # Try edge_tts first for real speech
+        tts_text = "Hello, this is a benchmark test for speech recognition latency. The quick brown fox jumps over the lazy dog."
+        tmp_wav = os.path.join(tempfile.gettempdir(), "benchmark_tts_test.wav")
+        if generate_test_audio_tts(tts_text, tmp_wav):
+            audio = load_audio(tmp_wav, target_sr=sample_rate)
+        else:
+            audio = generate_synthetic_audio(args.duration, sample_rate)
+            print(f"  ✅ Generated {args.duration}s synthetic audio")
+
+    audio_duration = len(audio) / sample_rate
+    print(f"   Audio duration: {audio_duration:.1f}s | Samples: {len(audio):,} | SR: {sample_rate}")
+
+    # ── Benchmark Whisper Tiny ──────────────────────────────────────────
+    whisper_times, whisper_text = benchmark_whisper_tiny(audio, sample_rate, args.runs)
+
+    # ── Benchmark SenseVoice ────────────────────────────────────────────
+    sv_times, sv_text = benchmark_sensevoice(audio, sample_rate, args.runs)
+
+    # ── Results ─────────────────────────────────────────────────────────
+    def stats(times):
+        return np.mean(times), np.min(times), np.max(times), np.std(times)
+
+    w_avg, w_min, w_max, w_std = stats(whisper_times)
+    s_avg, s_min, s_max, s_std = stats(sv_times)
+    speedup = w_avg / s_avg if s_avg > 0 else float("inf")
+    savings = w_avg - s_avg
+
+    print("\n")
+    print("=" * 60)
+    print("  📊 RESULTS")
+    print("=" * 60)
+    print(f"\n  Audio: {audio_duration:.1f}s @ {sample_rate}Hz | Device: {device}")
+    print(f"  Runs : {args.runs} (after 1 warm-up)\n")
+
+    headers = ["Model", "Avg (ms)", "Min (ms)", "Max (ms)", "Std (ms)", "RTF"]
+    rows = [
+        ["Whisper Tiny", f"{w_avg:.0f}", f"{w_min:.0f}", f"{w_max:.0f}",
+         f"{w_std:.0f}", f"{w_avg/1000/audio_duration:.3f}"],
+        ["SenseVoice Small", f"{s_avg:.0f}", f"{s_min:.0f}", f"{s_max:.0f}",
+         f"{s_std:.0f}", f"{s_avg/1000/audio_duration:.3f}"],
+    ]
+    print(format_table(headers, rows))
+
+    print(f"\n  🚀 SenseVoice is {speedup:.1f}x faster than Whisper Tiny")
+    print(f"  ⏱️  Latency savings: ~{savings:.0f}ms per utterance")
+
+    print(f"\n  Whisper output   : \"{whisper_text[:80]}\"")
+    print(f"  SenseVoice output: \"{sv_text[:80]}\"")
+
+    # ── Markdown output for PR ──────────────────────────────────────────
+    print("\n\n--- Markdown for PR description ---\n")
+    print(f"### ASR Latency Benchmark (Issue #604)\n")
+    print(f"**Audio:** {audio_duration:.1f}s | **Device:** {device} | **Runs:** {args.runs}\n")
+    print(f"| Model | Avg (ms) | Min (ms) | Max (ms) | RTF |")
+    print(f"|-------|----------|----------|----------|-----|")
+    print(f"| Whisper Tiny | {w_avg:.0f} | {w_min:.0f} | {w_max:.0f} | {w_avg/1000/audio_duration:.3f} |")
+    print(f"| SenseVoice Small | {s_avg:.0f} | {s_min:.0f} | {s_max:.0f} | {s_avg/1000/audio_duration:.3f} |")
+    print(f"\n> **{speedup:.1f}x faster** — saves ~{savings:.0f}ms per utterance")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,8 @@ dashscope
 
 #typeguard==2.13.3
 #onnxruntime-gpu
+
+# Local ASR server (SenseVoice/FunASR) — Issue #604
+# Optional: remove these lines if you don't need local ASR
+funasr
+modelscope

--- a/server/asr_server.py
+++ b/server/asr_server.py
@@ -1,0 +1,257 @@
+###############################################################################
+#  ASR WebSocket Server — Local SenseVoice/FunASR Integration
+#
+#  Resolves: https://github.com/lipku/LiveTalking/issues/604
+#
+#  This module provides a WebSocket endpoint (/api/asr) that speaks the same
+#  protocol as the external FunASR server (wss://www.funasr.com:10096/).
+#  The browser client (web/asr/main.js) can connect here instead, keeping
+#  all ASR processing local and cutting ~600ms of network + Whisper latency.
+#
+#  Copyright (C) 2024 LiveTalking@lipku https://github.com/lipku/LiveTalking
+#  Licensed under the Apache License, Version 2.0
+###############################################################################
+
+import json
+import time
+import io
+import asyncio
+import numpy as np
+from aiohttp import web
+
+from utils.logger import logger
+
+
+# ─── Lazy Model Loader ────────────────────────────────────────────────────
+
+_sensevoice_model = None
+
+
+def _load_sensevoice():
+    """
+    Load the SenseVoice model on first call (lazy singleton).
+    Thread-safe via the GIL — only one thread will enter the init block.
+    """
+    global _sensevoice_model
+    if _sensevoice_model is not None:
+        return _sensevoice_model
+
+    import torch
+    from funasr import AutoModel
+
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    logger.info(
+        f"[ASR] Loading SenseVoiceSmall on device='{device}' "
+        f"(first run will download ~500MB from ModelScope)..."
+    )
+
+    t0 = time.perf_counter()
+    _sensevoice_model = AutoModel(
+        model="iic/SenseVoiceSmall",
+        vad_model="fsmn-vad",
+        vad_kwargs={"max_single_segment_time": 30000},
+        device=device,
+        trust_remote_code=True,
+    )
+    elapsed = time.perf_counter() - t0
+    logger.info(f"[ASR] ✅ SenseVoiceSmall ready — loaded in {elapsed:.1f}s on {device}")
+    return _sensevoice_model
+
+
+def _run_inference(audio_float32: np.ndarray, sample_rate: int, use_itn: bool):
+    """
+    Run SenseVoice inference on a float32 audio array.
+
+    This is a **blocking** call — always invoke from ``run_in_executor``.
+
+    Returns
+    -------
+    tuple[str, float, float]
+        (transcribed_text, inference_ms, audio_duration_s)
+    """
+    import soundfile as sf
+    from funasr.utils.postprocess_utils import rich_transcription_postprocess
+
+    model = _load_sensevoice()
+
+    # Write to in-memory WAV so funasr can read the sample rate from the header
+    wav_buf = io.BytesIO()
+    sf.write(wav_buf, audio_float32, sample_rate, format="WAV")
+    wav_buf.seek(0)
+
+    t0 = time.perf_counter()
+    res = model.generate(
+        input=wav_buf,
+        cache={},
+        language="auto",
+        use_itn=use_itn,
+        batch_size_s=60,
+    )
+    inference_ms = (time.perf_counter() - t0) * 1000
+
+    text = ""
+    if res and len(res) > 0 and res[0].get("text"):
+        text = rich_transcription_postprocess(res[0]["text"])
+
+    audio_duration_s = len(audio_float32) / sample_rate
+
+    logger.info(
+        f"[ASR] ✅ SenseVoice inference complete\n"
+        f"       ├─ Latency     : {inference_ms:>8.0f} ms\n"
+        f"       ├─ Audio length: {audio_duration_s:>8.1f} s\n"
+        f"       ├─ RTF         : {inference_ms / 1000 / max(audio_duration_s, 0.001):>8.3f}\n"
+        f"       └─ Text        : \"{text[:100]}{'…' if len(text) > 100 else ''}\""
+    )
+
+    return text, inference_ms, audio_duration_s
+
+
+# ─── WebSocket Handler ─────────────────────────────────────────────────────
+
+SAMPLE_RATE = 16000  # The browser client records at 16 kHz mono PCM16
+
+
+async def asr_websocket_handler(request):
+    """
+    WebSocket handler implementing the FunASR client protocol.
+
+    Protocol flow
+    -------------
+    1. Client opens connection
+    2. Client sends JSON config::
+
+           {"chunk_size":[5,10,5], "wav_name":"h5",
+            "is_speaking":true, "mode":"2pass", "itn":false, ...}
+
+    3. Client streams binary PCM16 audio chunks (960 bytes = 60 ms @ 16 kHz)
+    4. Client sends stop signal::
+
+           {"is_speaking":false, ...}
+
+    5. Server responds with transcription::
+
+           {"text":"hello world", "mode":"2pass-offline",
+            "is_final":true, "timestamp":null}
+    """
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
+
+    client_ip = request.remote
+    logger.info(f"[ASR] 🔌 WebSocket connected from {client_ip}")
+
+    audio_buffer = bytearray()
+    config: dict = {}
+    session_start = time.perf_counter()
+    chunks_received = 0
+
+    try:
+        async for msg in ws:
+            if msg.type == web.WSMsgType.TEXT:
+                try:
+                    data = json.loads(msg.data)
+                except json.JSONDecodeError:
+                    logger.warning("[ASR] Received invalid JSON, ignoring")
+                    continue
+
+                if data.get("is_speaking") is True:
+                    # ── Session start ──────────────────────────────────
+                    config = data
+                    audio_buffer = bytearray()
+                    chunks_received = 0
+                    session_start = time.perf_counter()
+                    logger.info(
+                        f"[ASR] 🎙️  Recording started | "
+                        f"mode={config.get('mode', 'offline')} | "
+                        f"itn={config.get('itn', False)} | "
+                        f"hotwords={bool(config.get('hotwords'))}"
+                    )
+
+                elif data.get("is_speaking") is False:
+                    # ── End of speech → run inference ──────────────────
+                    buf_bytes = len(audio_buffer)
+                    audio_seconds = buf_bytes / (SAMPLE_RATE * 2)  # 2 bytes per int16
+                    session_elapsed = time.perf_counter() - session_start
+
+                    logger.info(
+                        f"[ASR] 🛑 Recording stopped | "
+                        f"{chunks_received} chunks | "
+                        f"{buf_bytes:,} bytes | "
+                        f"{audio_seconds:.1f}s audio | "
+                        f"session wall time {session_elapsed:.1f}s"
+                    )
+
+                    if buf_bytes < 640:  # < 20 ms of audio — skip
+                        logger.warning("[ASR] Audio too short (< 20ms), returning empty")
+                        await ws.send_str(json.dumps({
+                            "text": "",
+                            "mode": config.get("mode", "offline"),
+                            "is_final": True,
+                            "timestamp": None,
+                        }))
+                        continue
+
+                    # Ensure even number of bytes for int16 conversion
+                    if buf_bytes % 2 != 0:
+                        logger.warning(f"[ASR] Odd number of bytes received ({buf_bytes}), dropping incomplete sample")
+                        audio_buffer = audio_buffer[:-1]
+                        buf_bytes -= 1
+
+                    # Convert PCM16 → float32 in [-1, 1]
+                    audio_int16 = np.frombuffer(bytes(audio_buffer), dtype=np.int16)
+                    audio_float32 = audio_int16.astype(np.float32) / 32768.0
+                    use_itn = config.get("itn", False)
+
+                    # Offload blocking inference to a thread
+                    loop = asyncio.get_event_loop()
+                    try:
+                        text, inference_ms, audio_dur = await loop.run_in_executor(
+                            None,
+                            _run_inference,
+                            audio_float32,
+                            SAMPLE_RATE,
+                            use_itn,
+                        )
+                    except Exception as e:
+                        logger.exception(f"[ASR] ❌ Inference failed: {e}")
+                        text = ""
+
+                    # Map the client mode to the response mode the frontend expects
+                    mode = config.get("mode", "offline")
+                    if mode == "2pass":
+                        response_mode = "2pass-offline"
+                    else:
+                        response_mode = mode  # "online" or "offline"
+
+                    await ws.send_str(json.dumps({
+                        "text": text,
+                        "mode": response_mode,
+                        "is_final": True,
+                        "timestamp": None,
+                    }))
+                    logger.info(f"[ASR] 📤 Result sent to client (mode={response_mode})")
+
+            elif msg.type == web.WSMsgType.BINARY:
+                audio_buffer.extend(msg.data)
+                chunks_received += 1
+
+            elif msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):
+                break
+
+    except asyncio.CancelledError:
+        logger.info("[ASR] WebSocket handler cancelled")
+    except Exception as e:
+        logger.exception(f"[ASR] ❌ WebSocket handler error: {e}")
+
+    logger.info(f"[ASR] 🔌 WebSocket disconnected ({client_ip})")
+    return ws
+
+
+# ─── Availability Check ───────────────────────────────────────────────────
+
+def is_funasr_available() -> bool:
+    """Return True if the ``funasr`` package is importable."""
+    try:
+        import funasr  # noqa: F401
+        return True
+    except ImportError:
+        return False

--- a/server/routes.py
+++ b/server/routes.py
@@ -203,6 +203,18 @@ def setup_routes(app):
     app.router.add_get("/api/admin/config", admin_config)
     app.router.add_get("/api/admin/sessions", admin_sessions)
 
+    # ── Local ASR endpoint (SenseVoice/FunASR) ── Issue #604 ──
+    try:
+        from server.asr_server import asr_websocket_handler, is_funasr_available
+        if is_funasr_available():
+            app.router.add_get("/api/asr", asr_websocket_handler)
+            logger.info("[ASR] ✅ Local SenseVoice ASR endpoint enabled at /api/asr")
+        else:
+            logger.info("[ASR] funasr not installed — local ASR endpoint disabled "
+                        "(pip install funasr modelscope)")
+    except Exception as e:
+        logger.warning(f"[ASR] Failed to register ASR endpoint: {e}")
+
     # 注册 avatar 生成相关的路由
     setup_avatar_routes(app)
 

--- a/web/asr/main.js
+++ b/web/asr/main.js
@@ -51,12 +51,18 @@ var file_data_array;  // array to save file data
 var totalsend=0;
 
 
-// var now_ipaddress=window.location.href;
-// now_ipaddress=now_ipaddress.replace("https://","wss://");
-// now_ipaddress=now_ipaddress.replace("static/index.html","");
-// var localport=window.location.port;
-// now_ipaddress=now_ipaddress.replace(localport,"10095");
-// document.getElementById('wssip').value=now_ipaddress;
+// Auto-detect local ASR server endpoint (Issue #604: SenseVoice integration)
+// Falls back to the input field's default value if detection fails.
+(function() {
+	try {
+		var protocol = window.location.protocol === "https:" ? "wss://" : "ws://";
+		var host = window.location.host; // includes hostname:port
+		document.getElementById('wssip').value = protocol + host + "/api/asr";
+		console.log("[ASR] Auto-detected local endpoint: " + protocol + host + "/api/asr");
+	} catch(e) {
+		console.warn("[ASR] Auto-detect failed, using default address", e);
+	}
+})();
 addresschange();
 function addresschange()
 {   


### PR DESCRIPTION
## Fixes #604: Local ASR Server with SenseVoice/FunASR

This PR resolves issue #604 by implementing a local ASR WebSocket server using Alibaba's SenseVoiceSmall model, eliminating the need to send audio to the external `wss://www.funasr.com:10096/` server.

### Changes Made:
- **`server/asr_server.py`**: Added a new WebSocket handler that speaks the same protocol as the FunASR client in `main.js`. It runs SenseVoice inference asynchronously to avoid blocking the event loop.
- **`server/routes.py`**: Registered the `/api/asr` endpoint dynamically (only if `funasr` is installed).
- **`web/asr/main.js`**: Replaced the hardcoded remote WSS URL with auto-detection for the local `/api/asr` endpoint.
- **`benchmark_asr.py`**: Added a benchmarking script to easily compare ASR latency on the host machine.
- **`requirements.txt`**: Added optional dependencies `funasr` and `modelscope`.

### ASR Latency Benchmark (Issue #604)

**Audio:** 8.3s | **Device:** CPU | **Runs:** 3

| Model | Avg (ms) | Min (ms) | Max (ms) | RTF |
|-------|----------|----------|----------|-----|
| Whisper Tiny | 928 | 841 | 1048 | 0.111 |
| SenseVoice Small | 627 | 622 | 635 | 0.075 |

> **1.5x faster** (even on CPU) — saves ~300ms of conversational latency per utterance compared to Whisper Tiny, with zero network round-trip overhead.
